### PR TITLE
Repair wrong path to Poll, mods in close method

### DIFF
--- a/lib/Net/OpenSSH/Compat/SSH2.pm
+++ b/lib/Net/OpenSSH/Compat/SSH2.pm
@@ -302,7 +302,7 @@ sub tcpip { Carp::croak "method tcpip not implemented" }
 sub listen { Carp::croak "method listen not implemented" }
 
 sub poll {
-    require Net::OpenSSH::Compat::SSH::Poll;
+    require Net::OpenSSH::Compat::SSH2::Poll;
     goto &_poll;
 }
 
@@ -466,14 +466,14 @@ sub _slave_exited {
 sub DESTROY {
     my $chan = shift;
     my $ch = $chan->_hash;
-    $chan->close if $ch->{state} eq 'exec';
+    $chan->close if $ch->{state} eq 'exec' and defined $chan;
     $chan->SUPER::DESTROY;
 }
 
 sub wait_closed {
     my $chan = shift;
     my $ch = $chan->_hash;
-    shift->close if $ch->{state} eq 'exec';
+    shift->close if $ch->{state} eq 'exec' and defined shift;
     $ch->{state} eq 'closed';
 }
 


### PR DESCRIPTION
I have issue like a below:
Can't locate Net/OpenSSH/Compat/SSH/Poll.pm in @INC (you may need to install the Net::OpenSSH::Compat::SSH::Poll
...
at /opt/perl-5.18.3/lib/site_perl/5.18.2/Net/OpenSSH/Compat/SSH2.pm line 305.

also i got uninitialized error while trying to use close method in SSH2.pm line 476
